### PR TITLE
Prevent unnessary updates because of whitespace changes

### DIFF
--- a/logzio/common.go
+++ b/logzio/common.go
@@ -1,6 +1,9 @@
 package logzio
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 const (
 	BASE_10            int    = 10
@@ -16,4 +19,15 @@ func findStringInArray(v string, values []string) bool {
 		}
 	}
 	return false
+}
+
+func stripAllWhitespace(inputString string) string {
+	var b strings.Builder
+	b.Grow(len(inputString))
+	for _, ch := range inputString {
+		if !unicode.IsSpace(ch) {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
 }

--- a/logzio/common_test.go
+++ b/logzio/common_test.go
@@ -26,7 +26,6 @@ func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustSpaces(t *testi
 	assert.EqualValues(t, expected, stripAllWhitespace(input))
 }
 
-
 func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustTabs(t *testing.T) {
 	input := "				"
 	expected := ""
@@ -37,6 +36,22 @@ func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustTabs(t *testing
 func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustCharacters(t *testing.T) {
 	input := "abcdefghijklmnoplqrstuvwxyz"
 	expected := "abcdefghijklmnoplqrstuvwxyz"
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringHasWhiteSpaceAtFrontAndBack(t *testing.T) {
+	input := "     text with whitespace at front and back    	"
+	expected := "textwithwhitespaceatfrontandback"
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringHasCarraigeReturn(t *testing.T) {
+	input := `this string
+	spans multiple
+lines`
+	expected := "thisstringspansmultiplelines"
 
 	assert.EqualValues(t, expected, stripAllWhitespace(input))
 }

--- a/logzio/common_test.go
+++ b/logzio/common_test.go
@@ -1,0 +1,42 @@
+package logzio
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStripWhitespaceReturnsDesiredResult(t *testing.T) {
+	input := "test string with	tabs"
+	expected := "teststringwithtabs"
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsEmpty(t *testing.T) {
+	input := ""
+	expected := ""
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustSpaces(t *testing.T) {
+	input := "        "
+	expected := ""
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustTabs(t *testing.T) {
+	input := "				"
+	expected := ""
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustCharacters(t *testing.T) {
+	input := "abcdefghijklmnoplqrstuvwxyz"
+	expected := "abcdefghijklmnoplqrstuvwxyz"
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}

--- a/logzio/resource_alert.go
+++ b/logzio/resource_alert.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/jonboydell/logzio_client/alerts"
@@ -67,6 +68,9 @@ func resourceAlert() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "{\"bool\":{\"must\":[], \"must_not\":[]}}",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(stripAllWhitespace(old), stripAllWhitespace(old))
+				},
 			},
 			alert_group_by_aggregation_fields: {
 				Type:     schema.TypeList,


### PR DESCRIPTION
The jsonencode function in terraform is triggering updates to
logzio_alert resource when there are only whitespace changes (that
haven't actually been added decisively)

Fixes Issue https://github.com/bonjoydell/logzio_terraform_provider/issues/38
