### PR TITLE
Update logzio_terraform_client to v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform v0.12.6
-	github.com/logzio/logzio_terraform_client v1.2.0
+	github.com/logzio/logzio_terraform_client v1.3.0
 	github.com/stretchr/testify v1.3.0
 )


### PR DESCRIPTION
v1.2.0 gives the following error when running `go get`:

```plain
go: github.com/logzio/logzio_terraform_client@v1.2.0: parsing go.mod:
	module declares its path as: github.com/jonboydell/logzio_client
	        but was required as: github.com/logzio/logzio_terraform_client
```